### PR TITLE
Assorted tweaks and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3428,9 +3428,9 @@
       "dev": true
     },
     "css-loader": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.1.1.tgz",
-      "integrity": "sha512-nZ4OC2g88+wOOdkVQ0yYy7T6uXSkb7I7UyMNnaevQQvVWskTSDRAz08ETl91et4ghVL6jfnzWUt0o2XaY0gyRg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.2.0.tgz",
+      "integrity": "sha512-ko7a9b0iFpWtk9eSI/C8IICvZeGtYnjxYjw45rJprokXj/+kBd/siX4vAIBq9Uij8Jubc4jL1EvSnTjCEwaHSw==",
       "dev": true,
       "requires": {
         "camelcase": "^6.0.0",
@@ -6745,9 +6745,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@types/file-saver": "^2.0.1",
         "appwrite": "^1.0.29",
         "cross-env": "^7.0.2",
-        "css-loader": "^4.1.1",
+        "css-loader": "^4.2.0",
         "electron": "^9.1.2",
         "electron-builder": "^22.8.0",
         "eslint": "^7.5.0",

--- a/src/components/Forms/Button.svelte
+++ b/src/components/Forms/Button.svelte
@@ -8,6 +8,7 @@
   button {
     border: 1px solid;
     padding: 0.25em 1em;
+    margin: 0 0.5em 0 0.5em;
     cursor: pointer;
     float: left;
     border-color: #0077b8;

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -194,7 +194,7 @@
             },
             "edit": {
                 "order": "Szenen anordnen",
-                "buttonSave": "Szene speichern",
+                "buttonSave": "Speichern",
                 "buttonDelete": "Löschen"
             }
         }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -180,6 +180,14 @@
         "cloud": {
             "title": "EPUB",
             "subtitle": "Internet connection is needed for this."
+        },
+        "rtf": {
+            "title": "RTF",
+            "subtitle": "Export to RTF file format"
+        },
+        "json": {
+            "title": "JSON",
+            "subtitle": "Export to JSON file format"
         }
     },
     "sidebar": {
@@ -201,7 +209,7 @@
             },
             "edit": {
                 "order": "Order scenes",
-                "buttonSave": "Save Scene",
+                "buttonSave": "Save",
                 "buttonDelete": "Delete"
             }
         }
@@ -219,7 +227,12 @@
             "language": {
                 "title": "Language",
                 "en": "English",
-                "de": "German"
+                "de": "German",
+                "es": "Spanish",
+                "it": "Italian",
+                "pt": "Portuguese",
+                "ru": "Russian",
+                "fr": "French"
             }
         },
         "common": {

--- a/src/routes/Export/Cloud.svelte
+++ b/src/routes/Export/Cloud.svelte
@@ -47,7 +47,7 @@
     const exportApi =
         'https://omniawrite-git-11.torstendittmann.vercel.app/api/export';
 
-    const languages = ['en', 'de', 'ru', 'es', 'pt', 'fr', 'uk'].map(
+    const languages = ['en', 'de', 'ru', 'es', 'pt', 'fr', 'it'].map(
         (language) => {
             return {
                 value: language,

--- a/src/routes/Export/Cloud/collectData.js
+++ b/src/routes/Export/Cloud/collectData.js
@@ -13,7 +13,23 @@ export default class Export {
   }
   async fetchData() {
     const blockMapper = (currentBlock) => {
-      return currentBlock.data ? `<p>${smartenText(currentBlock.data.text)}</p>` : [];
+      if (!currentBlock.data) return [];
+
+      const text = currentBlock.data.text
+        .replace(/(\s|<br \/>)+$/, ""); // trim whitespace and unnecessary linebreaks at the end
+
+      switch (currentBlock.type) {
+        case "paragraph":
+          return `<p>${smartenText(text.replace("<br />", "</p><p>"))}</p>`;
+        case "quote":
+          return `<blockquote>${smartenText(text)}</blockquote>`;
+        case "heading":
+          return `<h2>${smartenText(text)}</h2>`;
+        case "code":
+          return `<pre><code>${text}</code></pre>`;
+        default:
+          return `<p>${text}</p>`;
+      }
     }
     const sceneMapper = currentScene => currentScene.content.blocks.flatMap(blockMapper);
     const chapterMapper = (currentChapter) => {
@@ -23,7 +39,8 @@ export default class Export {
           .filter(scene => scene.chapter == currentChapter.id && scene.content)
           .sort(this.compare)
           .map(sceneMapper)
-          .join(" ")
+          .flat()
+          .join("")
       }
     };
     return get(chapters)

--- a/src/routes/Write.svelte
+++ b/src/routes/Write.svelte
@@ -148,7 +148,7 @@
         {/if}
       </div>
       <div class="editpane">
-        <h1 contenteditable="true">{currentScene.title}</h1>
+        <h1 contenteditable bind:textContent={currentScene.title} />
         <OmniaEditor
           bind:this={editor}
           data={currentScene.content}


### PR DESCRIPTION
- fix extra commas between paragraphs in EPUB export
- don't smarten code blocks
- change `uk` (redundant with `en`) to `it`
- bind scene titles
- add a few missing language entries (.en only)
- change buttonSave label to just "Save", as it is used for Chapters too
- add some space between Save/Delete buttons
- update a couple of NPM packages to suppress low severity warnings