### PR TITLE
Support u, em, strong tags in RTF export

### DIFF
--- a/src/routes/Export/Cloud/collectData.js
+++ b/src/routes/Export/Cloud/collectData.js
@@ -16,11 +16,11 @@ export default class Export {
       if (!currentBlock.data) return [];
 
       const text = currentBlock.data.text
-        .replace(/(\s|<br \/>)+$/, ""); // trim whitespace and unnecessary linebreaks at the end
+        .replace(/(\s|<br ?\/?>)+$/, ""); // trim whitespace and unnecessary linebreaks at the end
 
       switch (currentBlock.type) {
         case "paragraph":
-          return `<p>${smartenText(text.replace("<br />", "</p><p>"))}</p>`;
+          return `<p>${smartenText(text.replace(/<br ?\/?>/g, "</p><p>"))}</p>`;
         case "quote":
           return `<blockquote>${smartenText(text)}</blockquote>`;
         case "heading":

--- a/src/routes/Export/RTF/collectData.js
+++ b/src/routes/Export/RTF/collectData.js
@@ -16,10 +16,12 @@ const toRTF = (text) => {
     .replace(/\u2011/g, "\\_") // non-breaking hyphen
     .replace(/[^ -~]/g, c => `\\u${c.charCodeAt()}?`) // escape unicode
     .replace(/<br\W*>/gi, "\\line ") // line breaks
-    .replace(/<i>/gi, "\\i ") // italic
-    .replace(/<\/i>/gi, "\\i0 ")
-    .replace(/<b>/gi, "\\b ") // bold
-    .replace(/<\/b>/gi, "\\b0 ")
+    .replace(/<(i|em)>/gi, "\\i ") // italic
+    .replace(/<\/(i|em)>/gi, "\\i0 ")
+    .replace(/<(b|strong)>/gi, "\\b ") // bold
+    .replace(/<\/(b|strong)>/gi, "\\b0 ")
+    .replace(/<u>/gi, "\\ul ") // underline
+    .replace(/<\/u>/gi, "\\ul0 ")
     .replace(/&gt;/g, ">") // unescape HTML special characters
     .replace(/&lt;/g, "<")
     .replace(/&amp;/g, "&");


### PR DESCRIPTION
This patch makes sure <u>, <em> and <strong> tags are correctly exported to RTF. Also improves <br> tag support a bit.