### PR TITLE
Internationalize quotation marks

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -92,6 +92,6 @@ a {
     }
 
     q {
-        quotes: '„''“';
+        quotes: var(--quotation-marks);
     }
 }

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -28,6 +28,9 @@
         }
     },
     "write": {
+        "quote": {
+            "marks": "'„' '“' '‚' '‘'"
+        },
         "toolbar": {
             "words": "Wörter",
             "chars": "Zeichen",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -28,6 +28,9 @@
         }
     },
     "write": {
+        "quote": {
+            "marks": "'“' '”' '‘' '’'"
+        },
         "toolbar": {
             "words": "words",
             "chars": "characters",

--- a/src/routes/Write.svelte
+++ b/src/routes/Write.svelte
@@ -200,7 +200,7 @@
           </select>
         {/if}
       </div>
-      <div class="editpane">
+      <div class="editpane" style="--quotation-marks:{$_('write.quote.marks')}">
         <h1 contenteditable bind:textContent={currentScene.title} />
         <OmniaEditor
           bind:this={editor}


### PR DESCRIPTION
German and English use different characters for quotes. See [Wikipedia](https://en.wikipedia.org/wiki/Quotation_mark#Summary_table).